### PR TITLE
Added a fork limiter based on available cpu cores

### DIFF
--- a/init.php
+++ b/init.php
@@ -7,7 +7,35 @@ define('DIR_CORE_SERVER', DIR_ROOT . 'core' . DS . 'server' . DS);
 define('DIR_WRAPPERS', DIR_ROOT . 'wrappers' . DS);
 define('DIR_LOG', DIR_ROOT . 'logs');
 define('DEBUG_MODE', TRUE);
-define('FORK_COUNT', 8);
+
+//limit the number of forked processes to the number of available cpu cores
+function cpu_cores() {
+  $cores = 1;
+  if (is_file('/proc/cpuinfo')) {
+    $cpuinfo = file_get_contents('/proc/cpuinfo');
+    preg_match_all('/^processor/m', $cpuinfo, $matches);
+    $cores = count($matches[0]);
+  } else if ('WIN' == strtoupper(substr(PHP_OS, 0, 3))) {
+    $process = popen('wmic cpu get NumberOfLogicalProcessors', 'rb');
+    if (false !== $process) {
+      fgets($process);
+      $cores = intval(fgets($process));
+      pclose($process);
+    }
+  } else {
+    $process = popen('sysctl -a', 'rb');
+    if (false !== $process) {
+      $output = stream_get_contents($process);
+      preg_match('/hw.ncpu: (\d+)/', $output, $matches);
+      if ($matches) { $cores = intval($matches[1][0]); }
+      pclose($process);
+    }
+  }
+  
+  return $cores;
+}
+
+define('FORK_COUNT', cpu_cores());
 
 $error_level = E_ALL;
 


### PR DESCRIPTION
Limiting the number of forked processes is performance wise because usually creating more processes than the currently available cpu cores leads to unnecessary context switching or theoretically can eat whole cpu resources on badly configured shared server, especially when the cpu is slow